### PR TITLE
Fix clocks.json data: 03:00 (1913), 07:00 (Binns Clock), 12:00 (Wells 1392)

### DIFF
--- a/clocks.json
+++ b/clocks.json
@@ -127,7 +127,7 @@
   },
   {
     "time": "03:00",
-    "date": "1910-01-01",
+    "date": "1913-01-01",
     "src": "images/0300.jpg",
     "desc": "Grand Central Terminal Clock – 1913",
     "link": "https://en.wikipedia.org/wiki/Grand_Central_Terminal",
@@ -163,10 +163,10 @@
   },
   {
     "time": "07:00",
-    "date": "1969-01-01",
+    "date": "1960-01-01",
     "src": "images/0700.jpg",
-    "desc": "World Clock (Urania, Berlin) – 1969",
-    "link": "https://en.wikipedia.org/wiki/World_clock",
+    "desc": "Binns Clock (Edinburgh, Scotland) – 1960",
+    "link": "https://www.atlasobscura.com/places/binns-clock",
     "mnemonic": "1960 (Top Jazz)",
     "poetry": "Jazz notes drip like rain.\nEvery sound is a memory\nhe cannot hold.\nHe dances with shadows,\npretending they are her."
   },
@@ -208,10 +208,10 @@
   },
   {
     "time": "12:00",
-    "date": "1960-01-01",
+    "date": "1392-01-01",
     "src": "images/1200.jpg",
-    "desc": "Wells Cathedral clock – 1960",
-    "link": "https://www.atlasobscura.com/places/binns-clock",
+    "desc": "Wells Cathedral clock (England) – 1392",
+    "link": "https://en.wikipedia.org/wiki/Wells_Cathedral_clock",
     "mnemonic": "1392 (DuMB Nun)",
     "poetry": "Old knights circle endlessly.\nOne stops.\nRust flakes away from its jaw.\nIt points.\nVenice."
   }


### PR DESCRIPTION
Corrects three data issues in `clocks.json` so the 24-clock age-ladder is internally consistent — the founding years now increase monotonically from noon.

| Hour | Field | Was | Now |
|------|-------|-----|-----|
| 03:00 | date | 1910 | 1913 (Grand Central) |
| 07:00 | date / desc / link | 1969 · *World Clock (Berlin)* · `/wiki/World_clock` | 1960 · *Binns Clock (Edinburgh)* · `atlasobscura/binns-clock` |
| 12:00 | date / desc / link | 1960 · *Wells … 1960* · `atlasobscura/binns-clock` | 1392 · *Wells … (England) 1392* · `/wiki/Wells_Cathedral_clock` |

**07:00** had been a duplicate of the 09:00 Berlin World Clock; it is the **Binns Clock, Edinburgh (1960)**. The Binns atlasobscura link had been misfiled on the Wells entry — this swaps it back and gives Wells its own Wikipedia link.

After the fix the sequence is monotonic: `12:00→1392, 13:00→1405, … 09:00→1969, 10:00→2011, 11:00→2011`.

⚠️ Not in this PR (needs a binary asset): `images/0700.jpg` still shows the Berlin World Clock and should be replaced with a Binns Clock photo — the JSON `src` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
